### PR TITLE
Make ignores (aka. excludes) more predictable and more easily configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,21 +36,22 @@ Positional arguments:
 
 Options:
 
+- `--ignore [IGNORE ...]`
+  comma-separated list of paths to ignore (default: ".git/, \_\_pycache\_\_/, .DS_Store, \*.tmp, .env")
 - `--target-root TARGET_ROOT`
-  subfolder on target to synchronize to
+  subfolder on target to synchronize to (default: "")
 - `--target-port TARGET_PORT`
-  SSH port on target
+  SSH port on target (default: 22)
 - `--on-change ON_CHANGE`
-  command to be executed on remote host after any file change
+  command to be executed on remote host after any file change (default: None)
 - `--mutex-interval MUTEX_INTERVAL`
-  interval in which mutex is updated
+  interval in which mutex is updated (default: 10 seconds)
 
 ### Notes
 
 - We suggest you have some auto-reloading in place on the (slow) target machine, like [NiceGUI](https://nicegui.io).
 - Only one user per target host should run LiveSync at a time. Therefore LiveSync provides a mutex mechanism.
-- By default `.git/` folders are not synchronized.
-- All files and directories from the `.gitignore` of any source directory are also excluded from synchronization.
+- By default `.git/`, `__pycache__/`, `.DS_Store`, `*.tmp`, and `.env` folders and files are not synchronized.
 - You can create a `.syncignore` file in any source directory to skip additional files and directories from syncing.
 - If you pass a VSCode workspace file as `source`, LiveSync will synchronize each directory listed in the `folders` section.
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@ Positional arguments:
 
 Options:
 
-- `--ignore [IGNORE ...]`
-  comma-separated list of paths to ignore (default: ".git/, \_\_pycache\_\_/, .DS_Store, \*.tmp, .env")
 - `--target-root TARGET_ROOT`
   subfolder on target to synchronize to (default: "")
 - `--target-port TARGET_PORT`
@@ -51,8 +49,8 @@ Options:
 
 - We suggest you have some auto-reloading in place on the (slow) target machine, like [NiceGUI](https://nicegui.io).
 - Only one user per target host should run LiveSync at a time. Therefore LiveSync provides a mutex mechanism.
-- By default `.git/`, `__pycache__/`, `.DS_Store`, `*.tmp`, and `.env` folders and files are not synchronized.
 - You can create a `.syncignore` file in any source directory to skip additional files and directories from syncing.
+- If a `.syncignore` file doesn't exist, it is automatically created containing `.git/`, `__pycache__/`, `.DS_Store`, `*.tmp`, and `.env`.
 - If you pass a VSCode workspace file as `source`, LiveSync will synchronize each directory listed in the `folders` section.
 
 ## Installation

--- a/livesync/folder.py
+++ b/livesync/folder.py
@@ -50,7 +50,7 @@ class Folder:
         return f'{self.target.host}:{self.target_path}'
 
     def get_ignores(self) -> List[str]:
-        path = self.local_path / '.gitignore'
+        path = self.local_path / '.syncignore'
         if not path.is_file():
             path.write_text('\n'.join(DEFAULT_IGNORES))
         return [line.strip() for line in path.read_text().splitlines() if not line.startswith('#')]

--- a/livesync/livesync.py
+++ b/livesync/livesync.py
@@ -14,8 +14,12 @@ def git_summary(folders: List[Folder]) -> str:
 
 
 async def async_main() -> None:
-    parser = argparse.ArgumentParser(description='Repeatedly synchronize local directories with remote machine')
+    parser = argparse.ArgumentParser(
+        description='Repeatedly synchronize local directories with remote machine',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('source', type=str, help='local source folder or VSCode workspace file')
+    parser.add_argument('--ignore', nargs='*', type=str, default='.git/, __pycache__/, .DS_Store, *.tmp, .env',
+                        help='comma-separated list of paths to ignore')
     parser.add_argument('--target-root', type=str, default='', help='subfolder on target to synchronize to')
     parser.add_argument('--target-port', type=int, default=22, help='SSH port on target')
     parser.add_argument('--on-change', type=str, help='command to be executed on remote host after any file change')
@@ -24,14 +28,15 @@ async def async_main() -> None:
     args = parser.parse_args()
     source = Path(args.source)
     target = Target(host=args.host, port=args.target_port, root=Path(args.target_root))
+    ignores = [word.strip() for word in str(args.ignore).split(',')]
 
     folders: List[Folder] = []
     if source.is_file():
         workspace = json.loads(source.read_text())
         paths = [Path(f['path']) for f in workspace['folders']]
-        folders = [Folder(p, target) for p in paths if p.is_dir()]
+        folders = [Folder(p, target, ignores) for p in paths if p.is_dir()]
     else:
-        folders = [Folder(source, target)]
+        folders = [Folder(source, target, ignores)]
 
     for folder in folders:
         if not folder.local_path.is_dir():

--- a/livesync/livesync.py
+++ b/livesync/livesync.py
@@ -18,8 +18,6 @@ async def async_main() -> None:
         description='Repeatedly synchronize local directories with remote machine',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('source', type=str, help='local source folder or VSCode workspace file')
-    parser.add_argument('--ignore', nargs='*', type=str, default='.git/, __pycache__/, .DS_Store, *.tmp, .env',
-                        help='comma-separated list of paths to ignore')
     parser.add_argument('--target-root', type=str, default='', help='subfolder on target to synchronize to')
     parser.add_argument('--target-port', type=int, default=22, help='SSH port on target')
     parser.add_argument('--on-change', type=str, help='command to be executed on remote host after any file change')
@@ -28,15 +26,14 @@ async def async_main() -> None:
     args = parser.parse_args()
     source = Path(args.source)
     target = Target(host=args.host, port=args.target_port, root=Path(args.target_root))
-    ignores = [word.strip() for word in str(args.ignore).split(',')]
 
     folders: List[Folder] = []
     if source.is_file():
         workspace = json.loads(source.read_text())
         paths = [Path(f['path']) for f in workspace['folders']]
-        folders = [Folder(p, target, ignores) for p in paths if p.is_dir()]
+        folders = [Folder(p, target) for p in paths if p.is_dir()]
     else:
-        folders = [Folder(source, target, ignores)]
+        folders = [Folder(source, target)]
 
     for folder in folders:
         if not folder.local_path.is_dir():

--- a/tests/test_syncing_with_git_summary.sh
+++ b/tests/test_syncing_with_git_summary.sh
@@ -5,6 +5,7 @@ set -e
 # create source folder
 mkdir -p /root/my_project
 echo 'file content' > /root/my_project/file.txt
+echo '.syncignore' > /root/my_project/.gitignore
 
 # create git repository
 cd /root/my_project
@@ -13,6 +14,7 @@ git config --global user.email "livesync@zauberzeug.com"
 git config --global user.name "Zauberzeug"
 git init
 git add file.txt
+git add .gitignore
 git commit -m 'initial commit'
 
 # livesync should create the target file


### PR DESCRIPTION
This PR tries to solve #9 by
- ignoring `.gitignore`,
- making excludes configurable via argparse, and
- renaming them to "ignores" (as in .syncignore).

See https://github.com/zauberzeug/livesync/issues/9#issuecomment-1773751381 for an ongoing discussion about how to combine it with a possibly existing .syncignore file.