### PR TITLE
Not creating subfolder when source is single dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Positional arguments:
 
 Options:
 
-- `--target-root TARGET_ROOT`
-  subfolder on target to synchronize to (default: source folder name)
+- `--target-path TARGET_PATH`
+  directory on target to synchronize to (default: home directory)
 - `--target-port TARGET_PORT`
   SSH port on target (default: 22)
 - `--on-change ON_CHANGE`

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Positional arguments:
 Options:
 
 - `--target-root TARGET_ROOT`
-  subfolder on target to synchronize to (default: "")
+  subfolder on target to synchronize to (default: source folder name)
 - `--target-port TARGET_PORT`
   SSH port on target (default: 22)
 - `--on-change ON_CHANGE`

--- a/livesync/folder.py
+++ b/livesync/folder.py
@@ -21,6 +21,7 @@ def run_subprocess(command: str, *, quiet: bool = False) -> None:
         print(e.stdout.decode())
         raise
 
+
 @dataclass(**KWONLY_SLOTS)
 class Target:
     host: str
@@ -45,12 +46,8 @@ class Folder:
         self._stop_watching = asyncio.Event()
 
     @property
-    def target_path(self) -> Path:
-        return self.target.root / self.local_path.stem
-
-    @property
     def ssh_path(self) -> str:
-        return f'{self.target.host}:{self.target_path}'
+        return f'{self.target.host}:{self.target.root}'
 
     def get_ignores(self) -> List[str]:
         path = self.local_path / '.syncignore'
@@ -92,4 +89,4 @@ class Folder:
         args += f' -e "ssh -p {self.target.port}"'
         run_subprocess(f'rsync {args} {self.local_path}/ {self.ssh_path}/', quiet=True)
         if post_sync_command:
-            run_subprocess(f'ssh {self.target.host} -p {self.target.port} "cd {self.target_path}; {post_sync_command}"')
+            run_subprocess(f'ssh {self.target.host} -p {self.target.port} "cd {self.target.root}; {post_sync_command}"')

--- a/livesync/folder.py
+++ b/livesync/folder.py
@@ -26,11 +26,10 @@ def run_subprocess(command: str, *, quiet: bool = False) -> None:
 class Target:
     host: str
     port: int
-    root: Path
+    path: Path
 
-    def make_target_root_directory(self) -> None:
-        print(f'make target root directory {self.root}')
-        run_subprocess(f'ssh {self.host} -p {self.port} "mkdir -p {self.root}"')
+    def make_target_directory(self) -> None:
+        run_subprocess(f'ssh {self.host} -p {self.port} "mkdir -p {self.path}"')
 
 
 class Folder:
@@ -47,7 +46,7 @@ class Folder:
 
     @property
     def ssh_path(self) -> str:
-        return f'{self.target.host}:{self.target.root}'
+        return f'{self.target.host}:{self.target.path}'
 
     def get_ignores(self) -> List[str]:
         path = self.local_path / '.syncignore'
@@ -89,4 +88,4 @@ class Folder:
         args += f' -e "ssh -p {self.target.port}"'
         run_subprocess(f'rsync {args} {self.local_path}/ {self.ssh_path}/', quiet=True)
         if post_sync_command:
-            run_subprocess(f'ssh {self.target.host} -p {self.target.port} "cd {self.target.root}; {post_sync_command}"')
+            run_subprocess(f'ssh {self.target.host} -p {self.target.port} "cd {self.target.path}; {post_sync_command}"')

--- a/livesync/livesync.py
+++ b/livesync/livesync.py
@@ -2,6 +2,7 @@
 import argparse
 import asyncio
 import sys
+from copy import copy
 from pathlib import Path
 from typing import List
 
@@ -31,8 +32,10 @@ async def async_main() -> None:
     folders: List[Folder] = []
     if source.is_file():
         workspace = pyjson5.decode(source.read_text())
-        paths = [Path(f['path']) for f in workspace['folders']]
-        folders = [Folder(p, target) for p in paths if p.is_dir()]
+        for path in [Path(f['path']) for f in workspace['folders']]:
+            folder_target = copy(target)
+            folder_target.root = folder_target.root / path.resolve().name
+            folders.append(Folder(path, folder_target))
     else:
         folders = [Folder(source, target)]
 

--- a/livesync/livesync.py
+++ b/livesync/livesync.py
@@ -2,7 +2,6 @@
 import argparse
 import asyncio
 import sys
-from copy import copy
 from pathlib import Path
 from typing import List
 
@@ -20,30 +19,25 @@ async def async_main() -> None:
         description='Repeatedly synchronize local directories with remote machine',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('source', type=str, help='local source folder or VSCode workspace file')
-    parser.add_argument(
-        '--target-root', type=str, default='',
-        help='subfolder on target to synchronize to; default is source folder name')
+    parser.add_argument('--target-path', type=str, default='', help='directory on target to synchronize to')
     parser.add_argument('--target-port', type=int, default=22, help='SSH port on target')
     parser.add_argument('--on-change', type=str, help='command to be executed on remote host after any file change')
     parser.add_argument('--mutex-interval', type=int, default=10, help='interval in which mutex is updated')
     parser.add_argument('host', type=str, help='the target host (e.g. username@hostname)')
     args = parser.parse_args()
     source = Path(args.source)
-    target = Target(host=args.host, port=args.target_port, root=Path(args.target_root))
 
     folders: List[Folder] = []
     if source.is_file():
         workspace = pyjson5.decode(source.read_text())
         for path in [Path(f['path']) for f in workspace['folders']]:
-            folder_target = copy(target)
-            folder_target.root = folder_target.root / path.resolve().name
-            folders.append(Folder(path, folder_target))
+            target_path = Path(args.target_path) / path.resolve().name
+            folders.append(Folder(path, Target(host=args.host, port=args.target_port, path=target_path)))
     else:
-        folder_target = copy(target)
-        if target.root == Path('.'):
-            folder_target.root = folder_target.root / source.resolve().name
-        print(f'Target root: {folder_target.root}')
-        folders = [Folder(source, folder_target)]
+        target_path = Path(args.target_path)
+        if not args.target_path:
+            target_path = Path(args.target_path) / source.resolve().name
+        folders.append(Folder(source, Target(host=args.host, port=args.target_port, path=target_path)))
 
     for folder in folders:
         if not folder.local_path.is_dir():
@@ -51,14 +45,14 @@ async def async_main() -> None:
             sys.exit(1)
 
     print('Checking mutex...')
-    mutex = Mutex(target)
+    mutex = Mutex(args.host, args.target_port)
     if not mutex.set(git_summary(folders)):
         print(f'Target is in use by {mutex.occupant}')
         sys.exit(1)
 
-    if args.target_root:
-        print('Creating target root directory...')
-        target.make_target_root_directory()
+    if args.target_path:
+        print('Creating target directory...')
+        Target(host=args.host, port=args.target_port, path=Path(args.target_path)).make_target_directory()
 
     print('Initial sync...')
     for folder in folders:

--- a/livesync/livesync.py
+++ b/livesync/livesync.py
@@ -20,7 +20,9 @@ async def async_main() -> None:
         description='Repeatedly synchronize local directories with remote machine',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('source', type=str, help='local source folder or VSCode workspace file')
-    parser.add_argument('--target-root', type=str, default='', help='subfolder on target to synchronize to')
+    parser.add_argument(
+        '--target-root', type=str, default='',
+        help='subfolder on target to synchronize to; default is source folder name')
     parser.add_argument('--target-port', type=int, default=22, help='SSH port on target')
     parser.add_argument('--on-change', type=str, help='command to be executed on remote host after any file change')
     parser.add_argument('--mutex-interval', type=int, default=10, help='interval in which mutex is updated')
@@ -37,7 +39,11 @@ async def async_main() -> None:
             folder_target.root = folder_target.root / path.resolve().name
             folders.append(Folder(path, folder_target))
     else:
-        folders = [Folder(source, target)]
+        folder_target = copy(target)
+        if target.root == Path('.'):
+            folder_target.root = folder_target.root / source.resolve().name
+        print(f'Target root: {folder_target.root}')
+        folders = [Folder(source, folder_target)]
 
     for folder in folders:
         if not folder.local_path.is_dir():

--- a/livesync/mutex.py
+++ b/livesync/mutex.py
@@ -4,15 +4,14 @@ import subprocess
 from datetime import datetime, timedelta
 from typing import Optional
 
-from .folder import Target
-
 MUTEX_FILEPATH = '~/.livesync_mutex'
 
 
 class Mutex:
 
-    def __init__(self, target: Target) -> None:
-        self.target = target
+    def __init__(self, host: str, port: int) -> None:
+        self.host = host
+        self.port = port
         self.occupant: Optional[str] = None
         self.user_id = socket.gethostname()
 
@@ -44,5 +43,5 @@ class Mutex:
         return f'{self.user_id} {datetime.now().isoformat()}'
 
     def _run_ssh_command(self, command: str) -> str:
-        ssh_command = ['ssh', self.target.host, '-p', str(self.target.port), command]
+        ssh_command = ['ssh', self.host, '-p', str(self.port), command]
         return subprocess.check_output(ssh_command, stderr=subprocess.DEVNULL).decode()

--- a/tests/test_syncing_vscode_workspace_with_multiple_folders.sh
+++ b/tests/test_syncing_vscode_workspace_with_multiple_folders.sh
@@ -21,6 +21,7 @@ echo '
 cd /root/project1
 livesync --target-port 2222 project1.code-workspace target &
 sleep 5
+assert_eq "0" "$?" "livesync exited abnormally"
 assert_eq "file content 1" "$(cat /target/project1/file.txt)" "wrong file content"
 assert_eq "file content 2" "$(cat /target/project2/file.txt)" "wrong file content"
 

--- a/tests/test_target_path.sh
+++ b/tests/test_target_path.sh
@@ -7,7 +7,7 @@ echo 'file content' > /root/my_project/file.txt
 
 # livesync should create the target file and run the on-change command
 cd /root/my_project
-livesync --target-port 2222 --target-root foo/bar . target &
+livesync --target-port 2222 --target-path foo/bar . target &
 sleep 5
 assert_eq "file content" "$(cat /target/foo/bar/file.txt)" "wrong file content"
 

--- a/tests/test_target_root.sh
+++ b/tests/test_target_root.sh
@@ -9,9 +9,9 @@ echo 'file content' > /root/my_project/file.txt
 cd /root/my_project
 livesync --target-port 2222 --target-root foo/bar . target &
 sleep 5
-assert_eq "file content" "$(cat /target/foo/bar/my_project/file.txt)" "wrong file content"
+assert_eq "file content" "$(cat /target/foo/bar/file.txt)" "wrong file content"
 
 # change source file, livesync should update the target file and run the on-change command again
 echo 'new file content' > file.txt
 sleep 5
-assert_eq "new file content" "$(cat /target/foo/bar/my_project/file.txt)" "wrong file content"
+assert_eq "new file content" "$(cat /target/foo/bar/file.txt)" "wrong file content"


### PR DESCRIPTION
This PR allows to target the specific directory where something should be synced to. Example:

```bash
livesync --root-target="~/robot" /home/rodja/feldfreund zauberzeug@192.168.43.1
```
now copies all code from `/home/rodja/feldfreund` on my machine to `/home/zauberzeug/robot` on the remote system. Before it used `/home/zauberzeug/robot/feldfreund` which is a bit strange and stems from the behaviour when we sync multiple dirs by having a vscode project file as source. There the behaviour of having single folders for each sub-project is correct and is not changed by this PR.