### PR TITLE
Convert symlinks on source to regular files on target

### DIFF
--- a/livesync/folder.py
+++ b/livesync/folder.py
@@ -83,7 +83,7 @@ class Folder:
         self._stop_watching.set()
 
     def sync(self, post_sync_command: Optional[str] = None) -> None:
-        args = '--prune-empty-dirs --delete -avz --checksum --no-t'
+        args = '--prune-empty-dirs -L --delete -avz --checksum --no-t'
         # args += ' --mkdirs'  # INFO: this option is not available in rsync < 3.2.3
         args += ''.join(f' --exclude="{e}"' for e in self.get_ignores())
         args += f' -e "ssh -p {self.target.port}"'


### PR DESCRIPTION
This PR adds the `-L` option to rsync. This will dereferences symbolic links, meaning that if the source file is a symlink, it will copy the file or directory it points to, rather than the symlink itself. Symlinks are often meaningless on the target so it's better to copy the data behind the symlink.