### PR TITLE
Introduce --ignore-mutex option

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,7 +17,7 @@
   "[python]": {
     "editor.defaultFormatter": "ms-python.autopep8",
     "editor.codeActionsOnSave": {
-      "source.organizeImports": true
+      "source.organizeImports": "explicit"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Options:
   command to be executed on remote host after any file change (default: None)
 - `--mutex-interval MUTEX_INTERVAL`
   interval in which mutex is updated (default: 10 seconds)
+- `--ignore-mutex`
+  ignore mutex (use with caution) (default: False)
 
 ### Python
 

--- a/livesync/livesync.py
+++ b/livesync/livesync.py
@@ -13,12 +13,13 @@ def main():
     parser.add_argument('--ssh-port', type=int, default=22, help='SSH port on target')
     parser.add_argument('--on-change', type=str, help='command to be executed on remote host after any file change')
     parser.add_argument('--mutex-interval', type=int, default=10, help='interval in which mutex is updated')
+    parser.add_argument('--ignore-mutex', action='store_true', help='ignore mutex (use with caution)')
     parser.add_argument('rsync_args', nargs=argparse.REMAINDER, help='arbitrary rsync parameters after "--"')
     args = parser.parse_args()
 
     folder = Folder(args.source, args.target, ssh_port=args.ssh_port, on_change=args.on_change)
     folder.rsync_args(' '.join(args.rsync_args))
-    sync(folder, mutex_interval=args.mutex_interval)
+    sync(folder, mutex_interval=args.mutex_interval, ignore_mutex=args.ignore_mutex)
 
 
 if __name__ == '__main__':

--- a/livesync/sync.py
+++ b/livesync/sync.py
@@ -30,13 +30,11 @@ async def run_folder_tasks(folders: Iterable[Folder], mutex_interval: float, ign
             asyncio.create_task(folder.watch())
 
         while True:
-            if ignore_mutex:
-                await asyncio.sleep(0)
-                continue
-            summary = get_summary(folders)
-            for mutex in mutexes.values():
-                if not mutex.set(summary):
-                    break
+            if not ignore_mutex:
+                summary = get_summary(folders)
+                for mutex in mutexes.values():
+                    if not mutex.set(summary):
+                        break
             await asyncio.sleep(mutex_interval)
     except Exception as e:
         print(e)

--- a/livesync/sync.py
+++ b/livesync/sync.py
@@ -10,15 +10,16 @@ def get_summary(folders: Iterable[Folder]) -> str:
     return '\n'.join(folder.get_summary() for folder in folders).replace('"', '\'')
 
 
-async def run_folder_tasks(folders: Iterable[Folder], mutex_interval: float) -> None:
+async def run_folder_tasks(folders: Iterable[Folder], mutex_interval: float, ignore_mutex: bool = False) -> None:
     try:
-        summary = get_summary(folders)
-        mutexes = {folder.host: Mutex(folder.host, folder.ssh_port) for folder in folders}
-        for mutex in mutexes.values():
-            print(f'Checking mutex on {mutex.host}', flush=True)
-            if not mutex.set(summary):
-                print(f'Target is in use by {mutex.occupant}')
-                sys.exit(1)
+        if not ignore_mutex:
+            summary = get_summary(folders)
+            mutexes = {folder.host: Mutex(folder.host, folder.ssh_port) for folder in folders}
+            for mutex in mutexes.values():
+                print(f'Checking mutex on {mutex.host}', flush=True)
+                if not mutex.set(summary):
+                    print(f'Target is in use by {mutex.occupant}')
+                    sys.exit(1)
 
         for folder in folders:
             print(f'  {folder.source_path} --> {folder.target}', flush=True)
@@ -29,6 +30,9 @@ async def run_folder_tasks(folders: Iterable[Folder], mutex_interval: float) -> 
             asyncio.create_task(folder.watch())
 
         while True:
+            if ignore_mutex:
+                await asyncio.sleep(0)
+                continue
             summary = get_summary(folders)
             for mutex in mutexes.values():
                 if not mutex.set(summary):
@@ -38,8 +42,8 @@ async def run_folder_tasks(folders: Iterable[Folder], mutex_interval: float) -> 
         print(e)
 
 
-def sync(*folders: Folder, mutex_interval: float = 10) -> None:
+def sync(*folders: Folder, mutex_interval: float = 10, ignore_mutex: bool = False) -> None:
     try:
-        asyncio.run(run_folder_tasks(folders, mutex_interval))
+        asyncio.run(run_folder_tasks(folders, mutex_interval, ignore_mutex=ignore_mutex))
     except KeyboardInterrupt:
         print('Bye!')


### PR DESCRIPTION
This PR introduces an option to ignore the mutex. This option is quite dangerous but can be useful if you know what you are doing. 

Example: two colleagues are preparing a system for delivery; one is developing the main code and has acquired the sync-mutex. But the other one wants to test some peripherals on the same system. By using the ignore-mutex option and syncing into an agreed folder the work can still be performed in parallel.