### PR TITLE
Added ignore to ignore directories when their metadata changes.

### DIFF
--- a/livesync/folder.py
+++ b/livesync/folder.py
@@ -55,7 +55,14 @@ class Folder:
         path = self.source_path / '.syncignore'
         if not path.is_file():
             path.write_text('\n'.join(self.DEFAULT_IGNORES))
-        return [line.strip() for line in path.read_text().splitlines() if not line.startswith('#')]
+        base_ignores = [line.strip() for line in path.read_text().splitlines() if not line.startswith('#')]
+        ignores = []
+        for ignore in base_ignores:
+            ignores.append(ignore)
+            if ignore.endswith("/") or ignore.endswith("\\"):
+                ignores.append(ignore.rstrip("/\\"))
+
+        return ignores
 
     def get_summary(self) -> str:
         summary = f'{self.source_path} --> {self.target}\n'

--- a/livesync/folder.py
+++ b/livesync/folder.py
@@ -55,13 +55,8 @@ class Folder:
         path = self.source_path / '.syncignore'
         if not path.is_file():
             path.write_text('\n'.join(self.DEFAULT_IGNORES))
-        base_ignores = [line.strip() for line in path.read_text().splitlines() if not line.startswith('#')]
-        ignores = []
-        for ignore in base_ignores:
-            ignores.append(ignore)
-            if ignore.endswith("/") or ignore.endswith("\\"):
-                ignores.append(ignore.rstrip("/\\"))
-
+        ignores = [line.strip() for line in path.read_text().splitlines() if not line.startswith('#')]
+        ignores += [ignore.rstrip('/\\') for ignore in ignores if ignore.endswith('/') or ignore.endswith('\\')]
         return ignores
 
     def get_summary(self) -> str:


### PR DESCRIPTION
Hello,

This PR should fix the issue of directories forcing a sync when changing metadata even though they are in the ignore list.
I want to mention that this will not enforce the exact same behaviour as the gitignore:

In order for the syncignore to behave like the gitignore, a pattern like "my_folder/" should ignore the folder "my_folder", but not the file "my_folder".
The gitignore differentiates between folders and files in this case, which cannot be done with the current way filters for watchfiles work.
This would require a change in the watchfile module.

I think this fix should be fine for now, since I would assume this behaviour of the gitignore rarely is intentionally used.