### PR TITLE
add new argument to not watch the copied folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Options:
   interval in which mutex is updated (default: 10 seconds)
 - `--ignore-mutex`
   ignore mutex (use with caution) (default: False)
+- `--no-watch`
+  don't keep watching the copied folders for changes after the sync (default: False)
 
 ### Python
 
@@ -64,6 +66,7 @@ sync(
 ```
 
 The `sync` call will block until the script is aborted.
+Only if `watch=False` is used, the `sync` call will end after copying the folders to the target once.
 The `Folder` class allows to set the `port` and an `on_change` bash command which is executed after a sync has been performed.
 Via the `rsync_args` build method you can pass additional options to configure rsync.
 

--- a/livesync/livesync.py
+++ b/livesync/livesync.py
@@ -14,12 +14,13 @@ def main():
     parser.add_argument('--on-change', type=str, help='command to be executed on remote host after any file change')
     parser.add_argument('--mutex-interval', type=int, default=10, help='interval in which mutex is updated')
     parser.add_argument('--ignore-mutex', action='store_true', help='ignore mutex (use with caution)')
+    parser.add_argument('--no-watch', action='store_true', help='do not watch for changes')
     parser.add_argument('rsync_args', nargs=argparse.REMAINDER, help='arbitrary rsync parameters after "--"')
     args = parser.parse_args()
 
     folder = Folder(args.source, args.target, ssh_port=args.ssh_port, on_change=args.on_change)
     folder.rsync_args(' '.join(args.rsync_args))
-    sync(folder, mutex_interval=args.mutex_interval, ignore_mutex=args.ignore_mutex)
+    sync(folder, mutex_interval=args.mutex_interval, ignore_mutex=args.ignore_mutex, watch=not args.no_watch)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds the option to not watch folders after copying them. Instead livesync just copies the folders and exits.
This also adds a new argument to the CLI (`--no-watch`) to use the option.