### PR TITLE
Add .jj as a default ignore

### DIFF
--- a/livesync/folder.py
+++ b/livesync/folder.py
@@ -13,7 +13,7 @@ from .run_subprocess import run_subprocess
 
 
 class Folder:
-    DEFAULT_IGNORES = ['.git/', '__pycache__/', '.DS_Store', '*.tmp', '.env']
+    DEFAULT_IGNORES = ['.git/', '.jj/', '__pycache__/', '.DS_Store', '*.tmp', '.env']
     DEFAULT_RSYNC_ARGS = ['--prune-empty-dirs', '--delete', '-a', '-v', '-z', '--checksum', '--no-t']
 
     def __init__(self,


### PR DESCRIPTION
`.jj` is the state folder for [jujutsu](https://github.com/jj-vcs/jj) which can be used as a git frontent. We don't want to sync those, just like `.git`.