### PR TITLE
Stop watch tasks if renewing mutex fails

### DIFF
--- a/livesync/sync.py
+++ b/livesync/sync.py
@@ -1,6 +1,6 @@
 import asyncio
 import sys
-from typing import Iterable
+from typing import Iterable, List, Tuple
 
 from .folder import Folder
 from .mutex import Mutex
@@ -28,7 +28,7 @@ async def run_folder_tasks(
             await folder.sync()
 
         if watch:
-            tasks = []
+            tasks: List[Tuple[Folder, asyncio.Task]] = []
             for folder in folders:
                 print(f'Watch folder {folder.source_path}', flush=True)
                 tasks.append((folder, asyncio.create_task(folder.watch())))
@@ -37,19 +37,13 @@ async def run_folder_tasks(
                 if not ignore_mutex:
                     summary = get_summary(folders)
 
-                    hosts_to_check = list(mutexes.keys())
-                    for host in hosts_to_check:
-                        if not await mutexes[host].set(summary):
-                            print(
-                                f'Target {host} is in use by {mutexes[host].occupant}, stopping watch tasks', flush=True)
-                            new_tasks = []
-                            for f, t in tasks:
-                                if f.host == host:
-                                    t.cancel()
-                                else:
-                                    new_tasks.append((f, t))
-                            tasks = new_tasks
-                            del mutexes[host]
+                    for host in list(mutexes):
+                        if await mutexes[host].set(summary):
+                            continue
+                        print(f'Target {host} is in use by {mutexes[host].occupant}, stopping watch tasks', flush=True)
+                        [task.cancel() for folder, task in tasks if folder.host == host]
+                        tasks = [(folder, task) for folder, task in tasks if folder.host != host]
+                        del mutexes[host]
 
                     if not tasks:
                         print('No more folders to watch, exiting', flush=True)

--- a/livesync/sync.py
+++ b/livesync/sync.py
@@ -28,16 +28,32 @@ async def run_folder_tasks(
             await folder.sync()
 
         if watch:
+            tasks = []
             for folder in folders:
                 print(f'Watch folder {folder.source_path}', flush=True)
-                asyncio.create_task(folder.watch())
+                tasks.append((folder, asyncio.create_task(folder.watch())))
 
             while True:
                 if not ignore_mutex:
                     summary = get_summary(folders)
-                    for mutex in mutexes.values():
-                        if not await mutex.set(summary):
-                            break
+
+                    hosts_to_check = list(mutexes.keys())
+                    for host in hosts_to_check:
+                        if not await mutexes[host].set(summary):
+                            print(
+                                f'Target {host} is in use by {mutexes[host].occupant}, stopping watch tasks', flush=True)
+                            new_tasks = []
+                            for f, t in tasks:
+                                if f.host == host:
+                                    t.cancel()
+                                else:
+                                    new_tasks.append((f, t))
+                            tasks = new_tasks
+                            del mutexes[host]
+
+                    if not tasks:
+                        print('No more folders to watch, exiting', flush=True)
+                        break
                 await asyncio.sleep(mutex_interval)
     except Exception as e:
         print(e)


### PR DESCRIPTION
I've stumbled upon this during #32. Should fix #23.

I've tested this by manually messing with the lock file on the remote machine and it seems to work. I have not tested the scenario described in #23, because I don't have more than one machine in the office.